### PR TITLE
feat(auth): implement login endpoint with JWT authentication

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -112,6 +112,26 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/evonapulse/backend/controllers/AuthController.java
+++ b/backend/src/main/java/com/evonapulse/backend/controllers/AuthController.java
@@ -39,9 +39,4 @@ public class AuthController {
         UserAuthResponse response = userService.authenticate(req.getEmail(), req.getPassword());
         return ResponseEntity.ok(response);
     }
-
-    @GetMapping("/test")
-    public ResponseEntity<String> test() {
-        return ResponseEntity.ok("Hello world");
-    }
 }

--- a/backend/src/main/java/com/evonapulse/backend/controllers/AuthController.java
+++ b/backend/src/main/java/com/evonapulse/backend/controllers/AuthController.java
@@ -11,10 +11,7 @@ import com.evonapulse.backend.services.UserService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -41,5 +38,10 @@ public class AuthController {
     public ResponseEntity<UserAuthResponse> login(@Valid @RequestBody UserAuthRequest req) {
         UserAuthResponse response = userService.authenticate(req.getEmail(), req.getPassword());
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<String> test() {
+        return ResponseEntity.ok("Hello world");
     }
 }

--- a/backend/src/main/java/com/evonapulse/backend/controllers/AuthController.java
+++ b/backend/src/main/java/com/evonapulse/backend/controllers/AuthController.java
@@ -1,13 +1,14 @@
 package com.evonapulse.backend.controllers;
 
+import com.evonapulse.backend.dtos.UserAuthResponse;
 import com.evonapulse.backend.dtos.UserPublicResponse;
-import com.evonapulse.backend.dtos.UserRegisterRequest;
+import com.evonapulse.backend.dtos.UserAuthRequest;
 import com.evonapulse.backend.entities.UserEntity;
+import com.evonapulse.backend.exceptions.PasswordIncorrectException;
 import com.evonapulse.backend.exceptions.RegistrationClosedException;
 import com.evonapulse.backend.mappers.UserMapper;
 import com.evonapulse.backend.services.UserService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,12 +28,18 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<UserPublicResponse> register(@Valid @RequestBody UserRegisterRequest user) {
+    public ResponseEntity<UserPublicResponse> register(@Valid @RequestBody UserAuthRequest user) {
         if (!userService.anyUserExist()) {
             UserEntity newUserEntity = userService.create(user.email, user.password);
             return ResponseEntity.status(HttpStatus.CREATED).body(userMapper.toUserPublicResponse(newUserEntity));
         } else {
             throw new RegistrationClosedException("Registration closed");
         }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<UserAuthResponse> login(@Valid @RequestBody UserAuthRequest req) {
+        UserAuthResponse response = userService.authenticate(req.getEmail(), req.getPassword());
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/evonapulse/backend/dtos/UserAuthRequest.java
+++ b/backend/src/main/java/com/evonapulse/backend/dtos/UserAuthRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
-public class UserRegisterRequest {
+public class UserAuthRequest {
     @NotBlank(message = "Email is mandatory")
     @Email(message = "Email should be valid")
     public String email;

--- a/backend/src/main/java/com/evonapulse/backend/dtos/UserAuthResponse.java
+++ b/backend/src/main/java/com/evonapulse/backend/dtos/UserAuthResponse.java
@@ -1,0 +1,13 @@
+package com.evonapulse.backend.dtos;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class UserAuthResponse {
+    public String id;
+    public String email;
+    public LocalDateTime createdAt;
+    public String token;
+}

--- a/backend/src/main/java/com/evonapulse/backend/exceptions/PasswordIncorrectException.java
+++ b/backend/src/main/java/com/evonapulse/backend/exceptions/PasswordIncorrectException.java
@@ -1,0 +1,11 @@
+package com.evonapulse.backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class PasswordIncorrectException extends RuntimeException {
+    public PasswordIncorrectException() {
+        super("Invalid password");
+    }
+}

--- a/backend/src/main/java/com/evonapulse/backend/mappers/UserMapper.java
+++ b/backend/src/main/java/com/evonapulse/backend/mappers/UserMapper.java
@@ -1,5 +1,6 @@
 package com.evonapulse.backend.mappers;
 
+import com.evonapulse.backend.dtos.UserAuthResponse;
 import com.evonapulse.backend.dtos.UserPublicResponse;
 import com.evonapulse.backend.entities.UserEntity;
 import org.mapstruct.Mapper;
@@ -7,4 +8,5 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface UserMapper {
     UserPublicResponse toUserPublicResponse(UserEntity user);
+    UserAuthResponse toUserAuthResponse(UserEntity user);
 }

--- a/backend/src/main/java/com/evonapulse/backend/repositories/JwtService.java
+++ b/backend/src/main/java/com/evonapulse/backend/repositories/JwtService.java
@@ -1,0 +1,55 @@
+package com.evonapulse.backend.repositories;
+
+import com.evonapulse.backend.entities.UserEntity;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.expiration}")
+    private long jwtExpirationMs;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    }
+
+    public String generateToken(UserEntity user) {
+        return Jwts.builder()
+                .setSubject(user.getId().toString())
+                .claim("email", user.getEmail())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtExpirationMs))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUserIdFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/com/evonapulse/backend/repositories/UserRepository.java
+++ b/backend/src/main/java/com/evonapulse/backend/repositories/UserRepository.java
@@ -3,7 +3,9 @@ package com.evonapulse.backend.repositories;
 import com.evonapulse.backend.entities.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<UserEntity, UUID> {
+    Optional<UserEntity> findByEmail(String email);
 }

--- a/backend/src/main/java/com/evonapulse/backend/security/JwtAuthFilter.java
+++ b/backend/src/main/java/com/evonapulse/backend/security/JwtAuthFilter.java
@@ -1,0 +1,59 @@
+package com.evonapulse.backend.security;
+
+import com.evonapulse.backend.entities.UserEntity;
+import com.evonapulse.backend.repositories.UserRepository;
+import io.jsonwebtoken.io.IOException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    public JwtAuthFilter(JwtService jwtService, UserRepository userRepository) {
+        this.jwtService = jwtService;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException, java.io.IOException {
+        final String authHeader = request.getHeader("Authorization");
+        final String token;
+        final String userId;
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        token = authHeader.substring(7);
+        if (!jwtService.isTokenValid(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        userId = jwtService.getUserIdFromToken(token);
+
+        UserEntity user = userRepository.findById(UUID.fromString(userId)).orElse(null);
+        if (user != null) {
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(user, null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/evonapulse/backend/security/JwtService.java
+++ b/backend/src/main/java/com/evonapulse/backend/security/JwtService.java
@@ -1,4 +1,4 @@
-package com.evonapulse.backend.repositories;
+package com.evonapulse.backend.security;
 
 import com.evonapulse.backend.entities.UserEntity;
 import io.jsonwebtoken.*;
@@ -13,10 +13,10 @@ import java.util.Date;
 public class JwtService {
 
     @Value("${jwt.secret}")
-    private String jwtSecret;
+    public String jwtSecret;
 
     @Value("${jwt.expiration}")
-    private long jwtExpirationMs;
+    public long jwtExpirationMs;
 
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(jwtSecret.getBytes());

--- a/backend/src/main/java/com/evonapulse/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/evonapulse/backend/security/SecurityConfig.java
@@ -3,12 +3,20 @@ package com.evonapulse.backend.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
+    private final JwtAuthFilter jwtAuthFilter;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+        this.jwtAuthFilter = jwtAuthFilter;
+    }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -17,8 +25,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())
-            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/login", "/api/auth/register").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/evonapulse/backend/services/UserService.java
+++ b/backend/src/main/java/com/evonapulse/backend/services/UserService.java
@@ -1,6 +1,10 @@
 package com.evonapulse.backend.services;
 
+import com.evonapulse.backend.dtos.UserAuthResponse;
 import com.evonapulse.backend.entities.UserEntity;
+import com.evonapulse.backend.exceptions.PasswordIncorrectException;
+import com.evonapulse.backend.mappers.UserMapper;
+import com.evonapulse.backend.repositories.JwtService;
 import com.evonapulse.backend.repositories.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -9,10 +13,17 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserMapper userMapper;
+    private final JwtService jwtService;
 
-    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public UserService(UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       UserMapper userMapper,
+                       JwtService jwtService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.userMapper = userMapper;
+        this.jwtService = jwtService;
     }
 
     public boolean anyUserExist() {
@@ -24,5 +35,20 @@ public class UserService {
         userEntity.setEmail(email);
         userEntity.setPasswordHash(passwordEncoder.encode(password));
         return userRepository.save(userEntity);
+    }
+
+    public UserAuthResponse authenticate(String email, String rawPassword) {
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(PasswordIncorrectException::new);
+
+        if (!passwordEncoder.matches(rawPassword, user.getPasswordHash())) {
+            throw new PasswordIncorrectException();
+        }
+
+        String token = jwtService.generateToken(user);
+
+        UserAuthResponse userAuthResponse = userMapper.toUserAuthResponse(user);
+        userAuthResponse.setToken(token);
+        return userAuthResponse;
     }
 }

--- a/backend/src/main/java/com/evonapulse/backend/services/UserService.java
+++ b/backend/src/main/java/com/evonapulse/backend/services/UserService.java
@@ -4,7 +4,7 @@ import com.evonapulse.backend.dtos.UserAuthResponse;
 import com.evonapulse.backend.entities.UserEntity;
 import com.evonapulse.backend.exceptions.PasswordIncorrectException;
 import com.evonapulse.backend.mappers.UserMapper;
-import com.evonapulse.backend.repositories.JwtService;
+import com.evonapulse.backend.security.JwtService;
 import com.evonapulse.backend.repositories.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 server.port=5000
+
+jwt.secret=${JWT_SECRET:defaultSecretChangeMe}
+jwt.expiration=${JWT_EXPIRATION:3600000}

--- a/backend/src/test/java/com/evonapulse/backend/services/JwtService.java
+++ b/backend/src/test/java/com/evonapulse/backend/services/JwtService.java
@@ -1,0 +1,57 @@
+package com.evonapulse.backend.services;
+
+import com.evonapulse.backend.entities.UserEntity;
+import com.evonapulse.backend.security.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtServiceTest {
+
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService();
+
+        jwtService.jwtSecret = "MySuperSecretKeyThatIsAtLeast256BitsLong123456";
+        jwtService.jwtExpirationMs = 3600000; // 1h
+    }
+
+    @Test
+    void testGenerateAndValidateToken() {
+        UserEntity user = new UserEntity();
+        user.setId(UUID.randomUUID());
+        user.setEmail("test@mail.com");
+
+        String token = jwtService.generateToken(user);
+
+        assertNotNull(token);
+        assertTrue(jwtService.isTokenValid(token));
+        assertEquals(user.getId().toString(), jwtService.getUserIdFromToken(token));
+    }
+
+    @Test
+    void testInvalidToken() {
+        String invalidToken = "invalid.jwt.token";
+
+        assertFalse(jwtService.isTokenValid(invalidToken));
+        assertThrows(Exception.class, () -> jwtService.getUserIdFromToken(invalidToken));
+    }
+
+    @Test
+    void testExpiredToken() throws InterruptedException {
+        jwtService.jwtExpirationMs = 1;
+
+        UserEntity user = new UserEntity();
+        user.setId(UUID.randomUUID());
+        user.setEmail("expired@mail.com");
+
+        String token = jwtService.generateToken(user);
+
+        Thread.sleep(10);
+    }
+}

--- a/backend/src/test/java/com/evonapulse/backend/services/UserServiceTest.java
+++ b/backend/src/test/java/com/evonapulse/backend/services/UserServiceTest.java
@@ -4,7 +4,7 @@ import com.evonapulse.backend.dtos.UserAuthResponse;
 import com.evonapulse.backend.entities.UserEntity;
 import com.evonapulse.backend.exceptions.PasswordIncorrectException;
 import com.evonapulse.backend.mappers.UserMapper;
-import com.evonapulse.backend.repositories.JwtService;
+import com.evonapulse.backend.security.JwtService;
 import com.evonapulse.backend.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/evonapulse/backend/services/UserServiceTest.java
+++ b/backend/src/test/java/com/evonapulse/backend/services/UserServiceTest.java
@@ -1,0 +1,125 @@
+package com.evonapulse.backend.services;
+
+import com.evonapulse.backend.dtos.UserAuthResponse;
+import com.evonapulse.backend.entities.UserEntity;
+import com.evonapulse.backend.exceptions.PasswordIncorrectException;
+import com.evonapulse.backend.mappers.UserMapper;
+import com.evonapulse.backend.repositories.JwtService;
+import com.evonapulse.backend.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private UserService userService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testAnyUserExist_ReturnsTrue() {
+        when(userRepository.count()).thenReturn(1L);
+        assertTrue(userService.anyUserExist());
+        verify(userRepository).count();
+    }
+
+    @Test
+    void testAnyUserExist_ReturnsFalse() {
+        when(userRepository.count()).thenReturn(0L);
+        assertFalse(userService.anyUserExist());
+        verify(userRepository).count();
+    }
+
+    @Test
+    void testCreate_Success() {
+        String email = "test@mail.com";
+        String rawPassword = "password";
+        String encodedPassword = "encoded";
+
+        UserEntity savedUser = new UserEntity();
+        savedUser.setEmail(email);
+        savedUser.setPasswordHash(encodedPassword);
+
+        when(passwordEncoder.encode(rawPassword)).thenReturn(encodedPassword);
+        when(userRepository.save(any(UserEntity.class))).thenReturn(savedUser);
+
+        UserEntity result = userService.create(email, rawPassword);
+
+        assertEquals(email, result.getEmail());
+        assertEquals(encodedPassword, result.getPasswordHash());
+        verify(userRepository).save(any(UserEntity.class));
+    }
+
+    @Test
+    void testAuthenticate_Success() {
+        String email = "user@mail.com";
+        String rawPassword = "password";
+        String hashedPassword = "hashedPassword";
+        String token = "jwt-token";
+
+        UserEntity user = new UserEntity();
+        user.setEmail(email);
+        user.setPasswordHash(hashedPassword);
+
+        UserAuthResponse expectedResponse = new UserAuthResponse();
+        expectedResponse.setId("user-id");
+        expectedResponse.setEmail(email);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(rawPassword, hashedPassword)).thenReturn(true);
+        when(jwtService.generateToken(user)).thenReturn(token);
+        when(userMapper.toUserAuthResponse(user)).thenReturn(expectedResponse);
+
+        UserAuthResponse result = userService.authenticate(email, rawPassword);
+
+        assertEquals(email, result.getEmail());
+        assertEquals(token, result.getToken());
+        verify(userRepository).findByEmail(email);
+        verify(passwordEncoder).matches(rawPassword, hashedPassword);
+        verify(jwtService).generateToken(user);
+        verify(userMapper).toUserAuthResponse(user);
+    }
+
+    @Test
+    void testAuthenticate_UserNotFound() {
+        when(userRepository.findByEmail("unknown@mail.com")).thenReturn(Optional.empty());
+
+        assertThrows(PasswordIncorrectException.class, () ->
+                userService.authenticate("unknown@mail.com", "anyPassword"));
+    }
+
+    @Test
+    void testAuthenticate_InvalidPassword() {
+        UserEntity user = new UserEntity();
+        user.setEmail("user@mail.com");
+        user.setPasswordHash("hashed");
+
+        when(userRepository.findByEmail("user@mail.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong", "hashed")).thenReturn(false);
+
+        assertThrows(PasswordIncorrectException.class, () ->
+                userService.authenticate("user@mail.com", "wrong"));
+    }
+}


### PR DESCRIPTION
## ✨ Feature: Implement login endpoint with JWT authentication

This PR introduces the user login feature using JWT-based authentication.

---

### ✅ Changes

- Added `POST /api/auth/login` route in `AuthController`
- Created `UserAuthResponse` DTO (merged with former `UserRegisterResponse`)
- Implemented `JwtService` for token generation and validation
- Added `JwtAuthFilter` to validate JWTs on protected routes
- Updated `SecurityConfig` to:
  - Allow public access to `/api/auth/login` and `/api/auth/register`
  - Require authentication for all other routes
- Added unit tests for:
  - `UserService` (login logic)
  - `JwtService` (token generation, validation)

---

### 🔐 Auth flow

1. User logs in via `/api/auth/login` with email/password
2. A JWT is generated and returned in the response
3. Token is required in `Authorization: Bearer <token>` for all other routes

---

### 🧪 Testing

- Unit tests written with JUnit & Mockito
- Manual validation with Postman using a shared JWT variable across requests

---

### 📌 Closes

Closes #1 
