### PR TITLE
Improvement: Make server port configurable via environment variable

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,4 +7,4 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
-server.port=5000
+server.port=${SERVER_PORT:5000}


### PR DESCRIPTION
## 🔧 Improvement: Make server port configurable via environment variable

This PR updates the server configuration to allow setting the HTTP port via an environment variable.

---

### ✅ Changes
- Set `server.port=${SERVER_PORT:5000}` in `application.properties`
- Allows overriding the default port (5000) using the `SERVER_PORT` environment variable

---

### 📦 Use case
This change simplifies:
- Running the app on different ports in dev/prod

---

### 🧪 Test
- Verified local override with `SERVER_PORT=6000`
