### PR TITLE
Feature/projects endpoint

### DIFF
--- a/backend/src/main/java/com/evonapulse/backend/controllers/ProjectController.java
+++ b/backend/src/main/java/com/evonapulse/backend/controllers/ProjectController.java
@@ -1,0 +1,74 @@
+package com.evonapulse.backend.controllers;
+
+import com.evonapulse.backend.dtos.ProjectCreateRequest;
+import com.evonapulse.backend.dtos.ProjectPublicResponse;
+import com.evonapulse.backend.dtos.ProjectUpdateRequest;
+import com.evonapulse.backend.entities.ProjectEntity;
+import com.evonapulse.backend.exceptions.ProjectNameAlreadyExistsException;
+import com.evonapulse.backend.mappers.ProjectMapper;
+import com.evonapulse.backend.services.ProjectService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+    private final ProjectMapper projectMapper;
+
+    public ProjectController(ProjectService projectService,
+                             ProjectMapper projectMapper) {
+        this.projectService = projectService;
+        this.projectMapper = projectMapper;
+    }
+
+    @GetMapping
+    public List<ProjectEntity> getAllProjects() {
+        return projectService.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProjectEntity> getProjectById(@PathVariable UUID id) {
+        return projectService.getById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<ProjectPublicResponse> createProject(@Valid @RequestBody ProjectCreateRequest request) {
+        if (projectService.nameExists(request.getName())) {
+            throw new ProjectNameAlreadyExistsException(request.getName());
+        }
+
+        return ResponseEntity.ok(projectMapper.toProjectPublicResponse(projectService.create(request)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateProject(@PathVariable UUID id,
+                                           @Valid @RequestBody ProjectUpdateRequest request) {
+        if (!projectService.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        if (projectService.nameExistsExcludingId(request.getName(), id)) {
+            throw new ProjectNameAlreadyExistsException(request.getName());
+        }
+
+        ProjectEntity updated = projectService.update(id, request);
+        return ResponseEntity.ok(updated);
+    }
+
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteProject(@PathVariable UUID id) {
+        boolean deleted = projectService.delete(id);
+        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/backend/src/main/java/com/evonapulse/backend/dtos/ProjectCreateRequest.java
+++ b/backend/src/main/java/com/evonapulse/backend/dtos/ProjectCreateRequest.java
@@ -1,0 +1,10 @@
+package com.evonapulse.backend.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ProjectCreateRequest {
+    @NotBlank
+    private String name;
+}

--- a/backend/src/main/java/com/evonapulse/backend/dtos/ProjectPublicResponse.java
+++ b/backend/src/main/java/com/evonapulse/backend/dtos/ProjectPublicResponse.java
@@ -1,0 +1,14 @@
+package com.evonapulse.backend.dtos;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ProjectPublicResponse {
+    public String id;
+    public String name;
+    public String apiKey;
+    public LocalDateTime createdAt;
+    public LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/evonapulse/backend/dtos/ProjectUpdateRequest.java
+++ b/backend/src/main/java/com/evonapulse/backend/dtos/ProjectUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.evonapulse.backend.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ProjectUpdateRequest {
+    @NotBlank
+    private String name;
+}

--- a/backend/src/main/java/com/evonapulse/backend/entities/ProjectEntity.java
+++ b/backend/src/main/java/com/evonapulse/backend/entities/ProjectEntity.java
@@ -1,0 +1,39 @@
+package com.evonapulse.backend.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "projects")
+@Getter @Setter
+public class ProjectEntity {
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String name;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String apiKey;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public ProjectEntity() {
+        this.id = UUID.randomUUID();
+        this.apiKey = UUID.randomUUID().toString();
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/evonapulse/backend/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/evonapulse/backend/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.evonapulse.backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ProjectNameAlreadyExistsException.class)
+    public ResponseEntity<Object> handleProjectNameAlreadyExists(ProjectNameAlreadyExistsException ex) {
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(RegistrationClosedException.class)
+    public ResponseEntity<Object> handleRegistrationClosed(RegistrationClosedException ex) {
+        return buildResponse(HttpStatus.FORBIDDEN, ex.getMessage());
+    }
+
+    @ExceptionHandler(PasswordIncorrectException.class)
+    public ResponseEntity<Object> handlePasswordIncorrect(PasswordIncorrectException ex) {
+        return buildResponse(HttpStatus.UNAUTHORIZED, ex.getMessage());
+    }
+
+    // fallback (optionnel)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleGenericException(Exception ex) {
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Unexpected error: " + ex.getMessage());
+    }
+
+    private ResponseEntity<Object> buildResponse(HttpStatus status, String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("message", message);
+        return new ResponseEntity<>(body, status);
+    }
+}

--- a/backend/src/main/java/com/evonapulse/backend/exceptions/ProjectNameAlreadyExistsException.java
+++ b/backend/src/main/java/com/evonapulse/backend/exceptions/ProjectNameAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.evonapulse.backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class ProjectNameAlreadyExistsException extends RuntimeException {
+    public ProjectNameAlreadyExistsException(String name) {
+        super("A project with the name '" + name + "' already exists.");
+    }
+}

--- a/backend/src/main/java/com/evonapulse/backend/mappers/ProjectMapper.java
+++ b/backend/src/main/java/com/evonapulse/backend/mappers/ProjectMapper.java
@@ -1,0 +1,10 @@
+package com.evonapulse.backend.mappers;
+
+import com.evonapulse.backend.dtos.ProjectPublicResponse;
+import com.evonapulse.backend.entities.ProjectEntity;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ProjectMapper {
+    ProjectPublicResponse toProjectPublicResponse(ProjectEntity project);
+}

--- a/backend/src/main/java/com/evonapulse/backend/repositories/ProjectRepository.java
+++ b/backend/src/main/java/com/evonapulse/backend/repositories/ProjectRepository.java
@@ -1,0 +1,11 @@
+package com.evonapulse.backend.repositories;
+
+import com.evonapulse.backend.entities.ProjectEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProjectRepository extends JpaRepository<ProjectEntity, UUID> {
+    boolean existsByName(String name);
+    boolean existsByNameAndIdNot(String name, UUID id);
+}

--- a/backend/src/main/java/com/evonapulse/backend/services/ProjectService.java
+++ b/backend/src/main/java/com/evonapulse/backend/services/ProjectService.java
@@ -43,7 +43,6 @@ public class ProjectService {
     public ProjectEntity create(ProjectCreateRequest request) {
         ProjectEntity project = new ProjectEntity();
         project.setName(request.getName());
-        project.setApiKey(UUID.randomUUID().toString());
         return projectRepository.save(project);
     }
 

--- a/backend/src/main/java/com/evonapulse/backend/services/ProjectService.java
+++ b/backend/src/main/java/com/evonapulse/backend/services/ProjectService.java
@@ -1,0 +1,64 @@
+package com.evonapulse.backend.services;
+
+import com.evonapulse.backend.dtos.ProjectCreateRequest;
+import com.evonapulse.backend.dtos.ProjectUpdateRequest;
+import com.evonapulse.backend.entities.ProjectEntity;
+import com.evonapulse.backend.repositories.ProjectRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    public ProjectService(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    public List<ProjectEntity> getAll() {
+        return projectRepository.findAll();
+    }
+
+    public Optional<ProjectEntity> getById(UUID id) {
+        return projectRepository.findById(id);
+    }
+
+    public boolean existsById(UUID id) {
+        return projectRepository.existsById(id);
+    }
+
+    public boolean nameExists(String name) {
+        return projectRepository.existsByName(name);
+    }
+
+    public boolean nameExistsExcludingId(String name, UUID id) {
+        return projectRepository.existsByNameAndIdNot(name, id);
+    }
+
+    public ProjectEntity create(ProjectCreateRequest request) {
+        ProjectEntity project = new ProjectEntity();
+        project.setName(request.getName());
+        project.setApiKey(UUID.randomUUID().toString());
+        return projectRepository.save(project);
+    }
+
+    public ProjectEntity update(UUID id, ProjectUpdateRequest request) {
+        ProjectEntity project = projectRepository.findById(id).orElseThrow();
+        project.setName(request.getName());
+        project.setUpdatedAt(LocalDateTime.now());
+        return projectRepository.save(project);
+    }
+
+    public boolean delete(UUID id) {
+        if (projectRepository.existsById(id)) {
+            projectRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}

--- a/backend/src/test/java/com/evonapulse/backend/controllers/ProjectControllerTest.java
+++ b/backend/src/test/java/com/evonapulse/backend/controllers/ProjectControllerTest.java
@@ -1,0 +1,150 @@
+package com.evonapulse.backend.controllers;
+
+import com.evonapulse.backend.dtos.ProjectCreateRequest;
+import com.evonapulse.backend.dtos.ProjectPublicResponse;
+import com.evonapulse.backend.dtos.ProjectUpdateRequest;
+import com.evonapulse.backend.entities.ProjectEntity;
+import com.evonapulse.backend.exceptions.ProjectNameAlreadyExistsException;
+import com.evonapulse.backend.mappers.ProjectMapper;
+import com.evonapulse.backend.services.ProjectService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ProjectControllerTest {
+
+    @Mock private ProjectService projectService;
+    @Mock private ProjectMapper projectMapper;
+
+    @InjectMocks private ProjectController projectController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllProjectsReturnsList() {
+        when(projectService.getAll()).thenReturn(Collections.emptyList());
+        List<ProjectEntity> result = projectController.getAllProjects();
+        assertNotNull(result);
+    }
+
+    @Test
+    void testGetProjectByIdFound() {
+        UUID id = UUID.randomUUID();
+        ProjectEntity entity = new ProjectEntity();
+        when(projectService.getById(id)).thenReturn(Optional.of(entity));
+
+        ResponseEntity<ProjectEntity> response = projectController.getProjectById(id);
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(entity, response.getBody());
+    }
+
+    @Test
+    void testGetProjectByIdNotFound() {
+        UUID id = UUID.randomUUID();
+        when(projectService.getById(id)).thenReturn(Optional.empty());
+
+        ResponseEntity<ProjectEntity> response = projectController.getProjectById(id);
+        assertEquals(404, response.getStatusCodeValue());
+    }
+
+    @Test
+    void testCreateProjectSuccess() {
+        ProjectCreateRequest req = new ProjectCreateRequest();
+        req.setName("Test Project");
+
+        ProjectEntity entity = new ProjectEntity();
+        ProjectPublicResponse response = new ProjectPublicResponse();
+
+        when(projectService.nameExists(req.getName())).thenReturn(false);
+        when(projectService.create(req)).thenReturn(entity);
+        when(projectMapper.toProjectPublicResponse(entity)).thenReturn(response);
+
+        ResponseEntity<ProjectPublicResponse> result = projectController.createProject(req);
+
+        assertEquals(200, result.getStatusCodeValue());
+        assertEquals(response, result.getBody());
+    }
+
+    @Test
+    void testCreateProjectNameConflict() {
+        ProjectCreateRequest req = new ProjectCreateRequest();
+        req.setName("Conflict");
+
+        when(projectService.nameExists(req.getName())).thenReturn(true);
+
+        assertThrows(ProjectNameAlreadyExistsException.class, () -> projectController.createProject(req));
+    }
+
+    @Test
+    void testUpdateProjectSuccess() {
+        UUID id = UUID.randomUUID();
+        ProjectUpdateRequest req = new ProjectUpdateRequest();
+        req.setName("Updated");
+
+        ProjectEntity updated = new ProjectEntity();
+
+        when(projectService.existsById(id)).thenReturn(true);
+        when(projectService.nameExistsExcludingId(req.getName(), id)).thenReturn(false);
+        when(projectService.update(id, req)).thenReturn(updated);
+
+        ResponseEntity<?> response = projectController.updateProject(id, req);
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(updated, response.getBody());
+    }
+
+    @Test
+    void testUpdateProjectNotFound() {
+        UUID id = UUID.randomUUID();
+        ProjectUpdateRequest req = new ProjectUpdateRequest();
+        req.setName("Updated");
+
+        when(projectService.existsById(id)).thenReturn(false);
+
+        ResponseEntity<?> response = projectController.updateProject(id, req);
+        assertEquals(404, response.getStatusCodeValue());
+    }
+
+    @Test
+    void testUpdateProjectNameConflict() {
+        UUID id = UUID.randomUUID();
+        ProjectUpdateRequest req = new ProjectUpdateRequest();
+        req.setName("Duplicate");
+
+        when(projectService.existsById(id)).thenReturn(true);
+        when(projectService.nameExistsExcludingId(req.getName(), id)).thenReturn(true);
+
+        assertThrows(ProjectNameAlreadyExistsException.class, () -> projectController.updateProject(id, req));
+    }
+
+    @Test
+    void testDeleteProjectSuccess() {
+        UUID id = UUID.randomUUID();
+        when(projectService.delete(id)).thenReturn(true);
+
+        ResponseEntity<Void> response = projectController.deleteProject(id);
+        assertEquals(204, response.getStatusCodeValue());
+    }
+
+    @Test
+    void testDeleteProjectNotFound() {
+        UUID id = UUID.randomUUID();
+        when(projectService.delete(id)).thenReturn(false);
+
+        ResponseEntity<Void> response = projectController.deleteProject(id);
+        assertEquals(404, response.getStatusCodeValue());
+    }
+}

--- a/backend/src/test/java/com/evonapulse/backend/services/ProjectServiceTest.java
+++ b/backend/src/test/java/com/evonapulse/backend/services/ProjectServiceTest.java
@@ -1,0 +1,114 @@
+package com.evonapulse.backend.services;
+
+import com.evonapulse.backend.dtos.ProjectCreateRequest;
+import com.evonapulse.backend.dtos.ProjectUpdateRequest;
+import com.evonapulse.backend.entities.ProjectEntity;
+import com.evonapulse.backend.repositories.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllReturnsList() {
+        when(projectRepository.findAll()).thenReturn(Collections.emptyList());
+        List<ProjectEntity> result = projectService.getAll();
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetByIdReturnsProject() {
+        UUID id = UUID.randomUUID();
+        ProjectEntity entity = new ProjectEntity();
+        when(projectRepository.findById(id)).thenReturn(Optional.of(entity));
+        Optional<ProjectEntity> result = projectService.getById(id);
+        assertTrue(result.isPresent());
+        assertEquals(entity, result.get());
+    }
+
+    @Test
+    void testExistsById() {
+        UUID id = UUID.randomUUID();
+        when(projectRepository.existsById(id)).thenReturn(true);
+        assertTrue(projectService.existsById(id));
+    }
+
+    @Test
+    void testNameExists() {
+        when(projectRepository.existsByName("MyProject")).thenReturn(true);
+        assertTrue(projectService.nameExists("MyProject"));
+    }
+
+    @Test
+    void testNameExistsExcludingId() {
+        UUID id = UUID.randomUUID();
+        when(projectRepository.existsByNameAndIdNot("MyProject", id)).thenReturn(true);
+        assertTrue(projectService.nameExistsExcludingId("MyProject", id));
+    }
+
+    @Test
+    void testCreateProject() {
+        ProjectCreateRequest request = new ProjectCreateRequest();
+        request.setName("New Project");
+
+        when(projectRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ProjectEntity result = projectService.create(request);
+
+        assertEquals("New Project", result.getName());
+        assertNotNull(result.getApiKey());
+    }
+
+    @Test
+    void testUpdateProject() {
+        UUID id = UUID.randomUUID();
+        ProjectUpdateRequest request = new ProjectUpdateRequest();
+        request.setName("Updated Name");
+
+        ProjectEntity existing = new ProjectEntity();
+        existing.setId(id);
+        when(projectRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(projectRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ProjectEntity updated = projectService.update(id, request);
+
+        assertEquals("Updated Name", updated.getName());
+        assertNotNull(updated.getUpdatedAt());
+    }
+
+    @Test
+    void testDeleteSuccess() {
+        UUID id = UUID.randomUUID();
+        when(projectRepository.existsById(id)).thenReturn(true);
+        boolean result = projectService.delete(id);
+        assertTrue(result);
+        verify(projectRepository).deleteById(id);
+    }
+
+    @Test
+    void testDeleteNotFound() {
+        UUID id = UUID.randomUUID();
+        when(projectRepository.existsById(id)).thenReturn(false);
+        boolean result = projectService.delete(id);
+        assertFalse(result);
+        verify(projectRepository, never()).deleteById(any());
+    }
+}


### PR DESCRIPTION
## ✨ Implement Project entity with full CRUD support

### Description

This PR implements the complete backend CRUD functionality for managing `Project` entities.

Each project has a unique `apiKey` and timestamps. All routes are protected by JWT authentication and validate name uniqueness.

---

### ✅ Features

- `ProjectEntity` created with fields: `id`, `name`, `apiKey`, `createdAt`, `updatedAt`
- Routes implemented:
  - `POST /api/projects` – create project
  - `GET /api/projects` – list all projects
  - `GET /api/projects/{id}` – fetch a project
  - `PUT /api/projects/{id}` – update project name
  - `DELETE /api/projects/{id}` – remove project
- Duplicate name checks handled at controller level (on create & update)

---

### 🧪 Tests

- Unit tests for `ProjectController` covering:
  - All routes and edge cases (404, name conflict)
- Unit tests for `ProjectService` covering:
  - `create`, `update`, `delete`, `getById`, `existsById`, and name checks

---

### 🛠 Technical Notes

- Introduced temporary `GlobalExceptionHandler` for consistent error formatting
- Error handling will be refactored via a dedicated issue (`#13`)
